### PR TITLE
Refactor startup and fix migration typo

### DIFF
--- a/OmdhSoft.Tasky/Src/Api/OmdhSoft.Tasky.Tasky.Api/Extensions/MigrationExtensions.cs
+++ b/OmdhSoft.Tasky/Src/Api/OmdhSoft.Tasky.Tasky.Api/Extensions/MigrationExtensions.cs
@@ -1,25 +1,23 @@
-﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
 using OmdhSoft.Tasky.Modules.Tasks.Api.Database;
 
-namespace OmdhSoft.Tasky.Tasky.Api.Extensions
+namespace OmdhSoft.Tasky.Tasky.Api.Extensions;
+
+internal static class MigrationExtensions
 {
-   internal static class MigrationExtensions
+    internal static void ApplyMigrations(this IApplicationBuilder app)
     {
-        internal static void ApplayMigrations(this IApplicationBuilder app)
-        {
-            using IServiceScope scope = app.ApplicationServices.CreateScope();
-            ApplyMigrations<TaskyDbContext>(scope);
-        }
+        using IServiceScope scope = app.ApplicationServices.CreateScope();
+        ApplyMigrations<TaskyDbContext>(scope);
+    }
 
-        private static void ApplyMigrations<TDbContext>(this IServiceScope scope)
+    private static void ApplyMigrations<TDbContext>(this IServiceScope scope)
         where TDbContext : DbContext
+    {
+        using TDbContext dbContext = scope.ServiceProvider.GetRequiredService<TDbContext>();
+        if (dbContext.Database.IsRelational())
         {
-
-            using TDbContext dbContext = scope.ServiceProvider.GetRequiredService<TDbContext>();
-            if (dbContext.Database.IsRelational())
-            {
-                dbContext.Database.Migrate();
-            }
+            dbContext.Database.Migrate();
         }
     }
 }

--- a/OmdhSoft.Tasky/Src/Api/OmdhSoft.Tasky.Tasky.Api/Program.cs
+++ b/OmdhSoft.Tasky/Src/Api/OmdhSoft.Tasky.Tasky.Api/Program.cs
@@ -4,33 +4,43 @@ using OmdhSoft.Tasky.Tasky.Api.Extensions;
 
 var builder = WebApplication.CreateBuilder(args);
 
-//builder.Services.AddOpenApi();
-builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen(c =>
-{
-    c.SwaggerDoc("v1", new OpenApiInfo
-    {
-        Title = "Tasky API",
-        Version = "v1"
-    });
-}); builder.Services.AddTasksModule(builder.Configuration);
+ConfigureServices(builder);
+
 var app = builder.Build();
 
-// Configure the HTTP request pipeline.
-if (app.Environment.IsDevelopment())
-{
-    //app.MapOpenApi();
-    app.UseSwagger();
-    app.UseSwaggerUI(c =>
-    {
-        c.SwaggerEndpoint("/swagger/v1/swagger.json", "Tasky API V1");
-        c.RoutePrefix = string.Empty; // Set Swagger UI at the app's root
-    });
-
-    app.ApplayMigrations();
-}
-
-TasksModule.MapEndpoints(app); 
+ConfigurePipeline(app);
 
 app.Run();
+
+static void ConfigureServices(WebApplicationBuilder builder)
+{
+    builder.Services.AddEndpointsApiExplorer();
+    builder.Services.AddSwaggerGen(c =>
+    {
+        c.SwaggerDoc("v1", new OpenApiInfo
+        {
+            Title = "Tasky API",
+            Version = "v1"
+        });
+    });
+
+    builder.Services.AddTasksModule(builder.Configuration);
+}
+
+static void ConfigurePipeline(WebApplication app)
+{
+    if (app.Environment.IsDevelopment())
+    {
+        app.UseSwagger();
+        app.UseSwaggerUI(c =>
+        {
+            c.SwaggerEndpoint("/swagger/v1/swagger.json", "Tasky API V1");
+            c.RoutePrefix = string.Empty; // Set Swagger UI at the app's root
+        });
+
+        app.ApplyMigrations();
+    }
+
+    TasksModule.MapEndpoints(app);
+}
  


### PR DESCRIPTION
## Summary
- streamline startup by isolating service registration and pipeline configuration
- correct migration helper typo by renaming ApplayMigrations to ApplyMigrations

## Testing
- `dotnet test OmdhSoft.Tasky.sln` *(fails: The current .NET SDK does not support targeting .NET 9.0)*
- `apt-get install -y dotnet-sdk-9.0` *(fails: Unable to locate package dotnet-sdk-9.0)*

------
https://chatgpt.com/codex/tasks/task_b_688f48db35d0832f8fdd05dd0ebf0349