### PR TITLE
feat: add audit and domain event abstractions

### DIFF
--- a/OmdhSoft.Tasky/Src/Modules/OmdhSoft.Tasky.Modules.Tasks.Api/Database/TaskyDbContext.cs
+++ b/OmdhSoft.Tasky/Src/Modules/OmdhSoft.Tasky.Modules.Tasks.Api/Database/TaskyDbContext.cs
@@ -1,17 +1,30 @@
-﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
 using OmdhSoft.Tasky.Modules.Tasks.Api.Tasks;
+using OmdhSoft.Tasky.Modules.Tasks.Api.Tasks.ValueObjects;
 
 namespace OmdhSoft.Tasky.Modules.Tasks.Api.Database
 {
-    public sealed class TaskyDbContext(DbContextOptions<TaskyDbContext> options):DbContext(options)
+    public sealed class TaskyDbContext(DbContextOptions<TaskyDbContext> options) : DbContext(options)
     {
-
-
         internal DbSet<Task> Tasks { get; set; }
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             base.OnModelCreating(modelBuilder);
-            modelBuilder.HasDefaultSchema(Schemas.Tasks); // Set the default schema for the Tasks module
+            modelBuilder.HasDefaultSchema(Schemas.Tasks);
+
+            modelBuilder.Entity<Task>(builder =>
+            {
+                builder.Property(t => t.Id)
+                    .HasConversion(id => id.Value, value => new TaskId(value));
+                builder.Property(t => t.Title)
+                    .HasConversion(title => title.Value, value => TaskTitle.From(value));
+                builder.Property(t => t.Description)
+                    .HasConversion(description => description.Value, value => TaskDescription.From(value));
+                builder.Property(t => t.Priority)
+                    .HasConversion(priority => priority.Value, value => TaskPriority.From(value));
+                builder.Property(t => t.Status)
+                    .HasConversion(status => status.Value, value => TaskStatus.From(value));
+            });
         }
     }
 }

--- a/OmdhSoft.Tasky/Src/Modules/OmdhSoft.Tasky.Modules.Tasks.Api/Tasks/CreateTask.cs
+++ b/OmdhSoft.Tasky/Src/Modules/OmdhSoft.Tasky.Modules.Tasks.Api/Tasks/CreateTask.cs
@@ -13,18 +13,18 @@ namespace OmdhSoft.Tasky.Modules.Tasks.Api.Tasks
         {
             app.MapPost("/tasks", async (CreateTaskRequest request, TaskyDbContext context) =>
             {
-                var @task = Task.Create(
+                var task = Task.Create(
                     request.Title,
                     request.Description,
                     request.Priority,
                     request.AssignedToUserId ?? Guid.Empty, // Assuming this is the user creating the task
                     Guid.NewGuid() // Placeholder for TaskListId, replace with actual logic
                 );
-                context.Tasks.Add(@task);
+                context.Tasks.Add(task);
                 await context.SaveChangesAsync();
                 return Results.Ok(task.Id);
 
-            }).WithTags(Tags.Tasks) ;
+            }).WithTags(Tags.Tasks);
         }
 
     }

--- a/OmdhSoft.Tasky/Src/Modules/OmdhSoft.Tasky.Modules.Tasks.Api/Tasks/CreateTaskRequest.cs
+++ b/OmdhSoft.Tasky/Src/Modules/OmdhSoft.Tasky.Modules.Tasks.Api/Tasks/CreateTaskRequest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using OmdhSoft.Tasky.Modules.Tasks.Api.Tasks.ValueObjects;
 
 namespace OmdhSoft.Tasky.Modules.Tasks.Api.Tasks;
 

--- a/OmdhSoft.Tasky/Src/Modules/OmdhSoft.Tasky.Modules.Tasks.Api/Tasks/Events/IDomainEvent.cs
+++ b/OmdhSoft.Tasky/Src/Modules/OmdhSoft.Tasky.Modules.Tasks.Api/Tasks/Events/IDomainEvent.cs
@@ -1,0 +1,5 @@
+namespace OmdhSoft.Tasky.Modules.Tasks.Api.Tasks.Events;
+
+public interface IDomainEvent
+{
+}

--- a/OmdhSoft.Tasky/Src/Modules/OmdhSoft.Tasky.Modules.Tasks.Api/Tasks/Events/TaskCompletedEvent.cs
+++ b/OmdhSoft.Tasky/Src/Modules/OmdhSoft.Tasky.Modules.Tasks.Api/Tasks/Events/TaskCompletedEvent.cs
@@ -1,0 +1,5 @@
+using OmdhSoft.Tasky.Modules.Tasks.Api.Tasks.ValueObjects;
+
+namespace OmdhSoft.Tasky.Modules.Tasks.Api.Tasks.Events;
+
+public sealed record TaskCompletedEvent(TaskId Id) : IDomainEvent;

--- a/OmdhSoft.Tasky/Src/Modules/OmdhSoft.Tasky.Modules.Tasks.Api/Tasks/Events/TaskCreatedEvent.cs
+++ b/OmdhSoft.Tasky/Src/Modules/OmdhSoft.Tasky.Modules.Tasks.Api/Tasks/Events/TaskCreatedEvent.cs
@@ -1,0 +1,5 @@
+using OmdhSoft.Tasky.Modules.Tasks.Api.Tasks.ValueObjects;
+
+namespace OmdhSoft.Tasky.Modules.Tasks.Api.Tasks.Events;
+
+public sealed record TaskCreatedEvent(TaskId Id, TaskTitle Title) : IDomainEvent;

--- a/OmdhSoft.Tasky/Src/Modules/OmdhSoft.Tasky.Modules.Tasks.Api/Tasks/Events/TaskDeletedEvent.cs
+++ b/OmdhSoft.Tasky/Src/Modules/OmdhSoft.Tasky.Modules.Tasks.Api/Tasks/Events/TaskDeletedEvent.cs
@@ -1,0 +1,5 @@
+using OmdhSoft.Tasky.Modules.Tasks.Api.Tasks.ValueObjects;
+
+namespace OmdhSoft.Tasky.Modules.Tasks.Api.Tasks.Events;
+
+public sealed record TaskDeletedEvent(TaskId Id) : IDomainEvent;

--- a/OmdhSoft.Tasky/Src/Modules/OmdhSoft.Tasky.Modules.Tasks.Api/Tasks/Events/TaskStatusChangedEvent.cs
+++ b/OmdhSoft.Tasky/Src/Modules/OmdhSoft.Tasky.Modules.Tasks.Api/Tasks/Events/TaskStatusChangedEvent.cs
@@ -1,0 +1,5 @@
+using OmdhSoft.Tasky.Modules.Tasks.Api.Tasks.ValueObjects;
+
+namespace OmdhSoft.Tasky.Modules.Tasks.Api.Tasks.Events;
+
+public sealed record TaskStatusChangedEvent(TaskId Id, TaskStatus Status) : IDomainEvent;

--- a/OmdhSoft.Tasky/Src/Modules/OmdhSoft.Tasky.Modules.Tasks.Api/Tasks/Events/TaskUpdatedEvent.cs
+++ b/OmdhSoft.Tasky/Src/Modules/OmdhSoft.Tasky.Modules.Tasks.Api/Tasks/Events/TaskUpdatedEvent.cs
@@ -1,0 +1,5 @@
+using OmdhSoft.Tasky.Modules.Tasks.Api.Tasks.ValueObjects;
+
+namespace OmdhSoft.Tasky.Modules.Tasks.Api.Tasks.Events;
+
+public sealed record TaskUpdatedEvent(TaskId Id) : IDomainEvent;

--- a/OmdhSoft.Tasky/Src/Modules/OmdhSoft.Tasky.Modules.Tasks.Api/Tasks/GetTask.cs
+++ b/OmdhSoft.Tasky/Src/Modules/OmdhSoft.Tasky.Modules.Tasks.Api/Tasks/GetTask.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.EntityFrameworkCore;
 using OmdhSoft.Tasky.Modules.Tasks.Api.Database;
+using OmdhSoft.Tasky.Modules.Tasks.Api.Tasks.ValueObjects;
 
 namespace OmdhSoft.Tasky.Modules.Tasks.Api.Tasks
 {
@@ -19,7 +20,7 @@ namespace OmdhSoft.Tasky.Modules.Tasks.Api.Tasks
             app.MapGet("/tasks/{id:guid}", async (Guid id, TaskyDbContext context) =>
                 {
                     TaskResponse? task = await context.Tasks
-                        .Where(e => e.Id == id)
+                        .Where(e => e.Id == (TaskId)id)
                         .Select(e => new TaskResponse(
                             e.Id,
                             e.Title,

--- a/OmdhSoft.Tasky/Src/Modules/OmdhSoft.Tasky.Modules.Tasks.Api/Tasks/IAuditable.cs
+++ b/OmdhSoft.Tasky/Src/Modules/OmdhSoft.Tasky.Modules.Tasks.Api/Tasks/IAuditable.cs
@@ -1,0 +1,6 @@
+namespace OmdhSoft.Tasky.Modules.Tasks.Api.Tasks;
+
+public interface IAuditable<TId>
+{
+    TId Id { get; }
+}

--- a/OmdhSoft.Tasky/Src/Modules/OmdhSoft.Tasky.Modules.Tasks.Api/Tasks/IFullAuditable.cs
+++ b/OmdhSoft.Tasky/Src/Modules/OmdhSoft.Tasky.Modules.Tasks.Api/Tasks/IFullAuditable.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace OmdhSoft.Tasky.Modules.Tasks.Api.Tasks;
+
+public interface IFullAuditable<TId> : IAuditable<TId>
+{
+    DateTime CreatedAt { get; }
+    DateTime? UpdatedAt { get; }
+    DateTime? DeletedAt { get; }
+    Guid CreatedByUserId { get; }
+    Guid? UpdatedByUserId { get; }
+    Guid? DeletedByUserId { get; }
+}

--- a/OmdhSoft.Tasky/Src/Modules/OmdhSoft.Tasky.Modules.Tasks.Api/Tasks/IFullAuditableWithEvent.cs
+++ b/OmdhSoft.Tasky/Src/Modules/OmdhSoft.Tasky.Modules.Tasks.Api/Tasks/IFullAuditableWithEvent.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using OmdhSoft.Tasky.Modules.Tasks.Api.Tasks.Events;
+
+namespace OmdhSoft.Tasky.Modules.Tasks.Api.Tasks;
+
+public interface IFullAuditableWithEvent<TId> : IFullAuditable<TId>
+{
+    IReadOnlyCollection<IDomainEvent> DomainEvents { get; }
+    void AddDomainEvent(IDomainEvent domainEvent);
+    void ClearDomainEvents();
+}

--- a/OmdhSoft.Tasky/Src/Modules/OmdhSoft.Tasky.Modules.Tasks.Api/Tasks/Task.cs
+++ b/OmdhSoft.Tasky/Src/Modules/OmdhSoft.Tasky.Modules.Tasks.Api/Tasks/Task.cs
@@ -1,42 +1,96 @@
 using System;
+using System.Collections.Generic;
+using OmdhSoft.Tasky.Modules.Tasks.Api.Tasks.Events;
+using OmdhSoft.Tasky.Modules.Tasks.Api.Tasks.ValueObjects;
 
 namespace OmdhSoft.Tasky.Modules.Tasks.Api.Tasks
 {
-    public class Task //: FullAuditableEntity<Guid>
+    public class Task : IFullAuditableWithEvent<TaskId>
     {
-
-        public Guid Id { get; private set; } = Guid.NewGuid();
+        public TaskId Id { get; private set; } = TaskId.New();
         public DateTime CreatedAt { get; private set; } = DateTime.UtcNow;
         public DateTime? UpdatedAt { get; private set; }
         public DateTime? DeletedAt { get; private set; }
         public Guid? DeletedByUserId { get; private set; }
         public Guid? UpdatedByUserId { get; private set; }
-        public string Title { get; private set; }
-        public string Description { get; private set; }
+        public TaskTitle Title { get; private set; }
+        public TaskDescription Description { get; private set; }
         public TaskPriority Priority { get; private set; }
         public TaskStatus Status { get; private set; }
         public DateTime? DueDate { get; private set; }
         public Guid CreatedByUserId { get; private set; }
         public Guid? AssignedToUserId { get; private set; }
-        //public Guid TaskListId { get; private set; }
+
+        private readonly List<IDomainEvent> _domainEvents = new();
+        public IReadOnlyCollection<IDomainEvent> DomainEvents => _domainEvents.AsReadOnly();
 
         private Task() { }
 
-        private Task(string title, string description, TaskPriority priority, Guid createdByUserId, Guid taskListId)
+        private Task(TaskTitle title, TaskDescription description, TaskPriority priority, Guid createdByUserId, Guid taskListId)
         {
             Title = title;
             Description = description;
             Priority = priority;
             CreatedByUserId = createdByUserId;
-           // TaskListId = taskListId;
             Status = TaskStatus.Pending;
             CreatedAt = DateTime.UtcNow;
-            //AddDomainEvent(new TaskCreatedEvent(Id, Title.Value));
+            AddDomainEvent(new TaskCreatedEvent(Id, Title));
         }
 
-        public static Task Create(string title, string description, TaskPriority priority, Guid createdByUserId, Guid taskListId)
+        public static Task Create(TaskTitle title, TaskDescription description, TaskPriority priority, Guid createdByUserId, Guid taskListId)
         {
             return new Task(title, description, priority, createdByUserId, taskListId);
+        }
+
+        public void Update(TaskTitle title, TaskDescription description, TaskPriority priority, Guid updatedByUserId)
+        {
+            Title = title;
+            Description = description;
+            Priority = priority;
+            UpdatedAt = DateTime.UtcNow;
+            UpdatedByUserId = updatedByUserId;
+            AddDomainEvent(new TaskUpdatedEvent(Id));
+        }
+
+        public void ChangeStatus(TaskStatus status, Guid updatedByUserId)
+        {
+            if (Status == status)
+            {
+                return;
+            }
+
+            Status = status;
+            UpdatedAt = DateTime.UtcNow;
+            UpdatedByUserId = updatedByUserId;
+            AddDomainEvent(new TaskStatusChangedEvent(Id, status));
+
+            if (status == TaskStatus.Completed)
+            {
+                AddDomainEvent(new TaskCompletedEvent(Id));
+            }
+        }
+
+        public void Delete(Guid deletedByUserId)
+        {
+            if (DeletedAt is not null)
+            {
+                return;
+            }
+
+            DeletedAt = DateTime.UtcNow;
+            DeletedByUserId = deletedByUserId;
+            Status = TaskStatus.Removed;
+            AddDomainEvent(new TaskDeletedEvent(Id));
+        }
+
+        public void AddDomainEvent(IDomainEvent domainEvent)
+        {
+            _domainEvents.Add(domainEvent);
+        }
+
+        public void ClearDomainEvents()
+        {
+            _domainEvents.Clear();
         }
     }
 }

--- a/OmdhSoft.Tasky/Src/Modules/OmdhSoft.Tasky.Modules.Tasks.Api/Tasks/TaskPriority.cs
+++ b/OmdhSoft.Tasky/Src/Modules/OmdhSoft.Tasky.Modules.Tasks.Api/Tasks/TaskPriority.cs
@@ -1,7 +1,0 @@
-public enum TaskPriority
-{
-    Low = 0,
-    Medium = 1,
-    High = 2,
-    Urgent = 3
-}

--- a/OmdhSoft.Tasky/Src/Modules/OmdhSoft.Tasky.Modules.Tasks.Api/Tasks/TaskResponse.cs
+++ b/OmdhSoft.Tasky/Src/Modules/OmdhSoft.Tasky.Modules.Tasks.Api/Tasks/TaskResponse.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using OmdhSoft.Tasky.Modules.Tasks.Api.Tasks.ValueObjects;
 
 namespace OmdhSoft.Tasky.Modules.Tasks.Api.Tasks;
 

--- a/OmdhSoft.Tasky/Src/Modules/OmdhSoft.Tasky.Modules.Tasks.Api/Tasks/TaskStatus.cs
+++ b/OmdhSoft.Tasky/Src/Modules/OmdhSoft.Tasky.Modules.Tasks.Api/Tasks/TaskStatus.cs
@@ -1,8 +1,0 @@
-public enum TaskStatus
-{
-    Pending  =0,
-    Published = 1,
-    Completed = 2,
-    Cancelled = 3,
-    Removed    =4
-}

--- a/OmdhSoft.Tasky/Src/Modules/OmdhSoft.Tasky.Modules.Tasks.Api/Tasks/ValueObjects/TaskDescription.cs
+++ b/OmdhSoft.Tasky/Src/Modules/OmdhSoft.Tasky.Modules.Tasks.Api/Tasks/ValueObjects/TaskDescription.cs
@@ -1,0 +1,18 @@
+namespace OmdhSoft.Tasky.Modules.Tasks.Api.Tasks.ValueObjects;
+
+public sealed class TaskDescription
+{
+    public string Value { get; }
+
+    private TaskDescription(string value)
+    {
+        Value = value;
+    }
+
+    public static TaskDescription From(string value) => new TaskDescription(value ?? string.Empty);
+
+    public override string ToString() => Value;
+
+    public static implicit operator string(TaskDescription description) => description.Value;
+    public static implicit operator TaskDescription(string value) => From(value);
+}

--- a/OmdhSoft.Tasky/Src/Modules/OmdhSoft.Tasky.Modules.Tasks.Api/Tasks/ValueObjects/TaskId.cs
+++ b/OmdhSoft.Tasky/Src/Modules/OmdhSoft.Tasky.Modules.Tasks.Api/Tasks/ValueObjects/TaskId.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace OmdhSoft.Tasky.Modules.Tasks.Api.Tasks.ValueObjects;
+
+public readonly record struct TaskId
+{
+    public Guid Value { get; }
+
+    public TaskId(Guid value)
+    {
+        if (value == Guid.Empty)
+        {
+            throw new ArgumentException("Task ID cannot be empty.", nameof(value));
+        }
+
+        Value = value;
+    }
+
+    public static TaskId New() => new(Guid.NewGuid());
+
+    public override string ToString() => Value.ToString();
+
+    public static implicit operator Guid(TaskId id) => id.Value;
+
+    public static implicit operator TaskId(Guid value) => new(value);
+}

--- a/OmdhSoft.Tasky/Src/Modules/OmdhSoft.Tasky.Modules.Tasks.Api/Tasks/ValueObjects/TaskPriority.cs
+++ b/OmdhSoft.Tasky/Src/Modules/OmdhSoft.Tasky.Modules.Tasks.Api/Tasks/ValueObjects/TaskPriority.cs
@@ -1,0 +1,32 @@
+using System;
+
+namespace OmdhSoft.Tasky.Modules.Tasks.Api.Tasks.ValueObjects;
+
+public readonly record struct TaskPriority
+{
+    public int Value { get; }
+
+    private TaskPriority(int value)
+    {
+        Value = value;
+    }
+
+    public static TaskPriority Low { get; } = new(0);
+    public static TaskPriority Medium { get; } = new(1);
+    public static TaskPriority High { get; } = new(2);
+    public static TaskPriority Urgent { get; } = new(3);
+
+    public static TaskPriority From(int value) => value switch
+    {
+        0 => Low,
+        1 => Medium,
+        2 => High,
+        3 => Urgent,
+        _ => throw new ArgumentOutOfRangeException(nameof(value), "Invalid priority value")
+    };
+
+    public override string ToString() => Value.ToString();
+
+    public static implicit operator int(TaskPriority priority) => priority.Value;
+    public static implicit operator TaskPriority(int value) => From(value);
+}

--- a/OmdhSoft.Tasky/Src/Modules/OmdhSoft.Tasky.Modules.Tasks.Api/Tasks/ValueObjects/TaskStatus.cs
+++ b/OmdhSoft.Tasky/Src/Modules/OmdhSoft.Tasky.Modules.Tasks.Api/Tasks/ValueObjects/TaskStatus.cs
@@ -1,0 +1,34 @@
+using System;
+
+namespace OmdhSoft.Tasky.Modules.Tasks.Api.Tasks.ValueObjects;
+
+public readonly record struct TaskStatus
+{
+    public int Value { get; }
+
+    private TaskStatus(int value)
+    {
+        Value = value;
+    }
+
+    public static TaskStatus Pending { get; } = new(0);
+    public static TaskStatus Published { get; } = new(1);
+    public static TaskStatus Completed { get; } = new(2);
+    public static TaskStatus Cancelled { get; } = new(3);
+    public static TaskStatus Removed { get; } = new(4);
+
+    public static TaskStatus From(int value) => value switch
+    {
+        0 => Pending,
+        1 => Published,
+        2 => Completed,
+        3 => Cancelled,
+        4 => Removed,
+        _ => throw new ArgumentOutOfRangeException(nameof(value), "Invalid status value")
+    };
+
+    public override string ToString() => Value.ToString();
+
+    public static implicit operator int(TaskStatus status) => status.Value;
+    public static implicit operator TaskStatus(int value) => From(value);
+}

--- a/OmdhSoft.Tasky/Src/Modules/OmdhSoft.Tasky.Modules.Tasks.Api/Tasks/ValueObjects/TaskTitle.cs
+++ b/OmdhSoft.Tasky/Src/Modules/OmdhSoft.Tasky.Modules.Tasks.Api/Tasks/ValueObjects/TaskTitle.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace OmdhSoft.Tasky.Modules.Tasks.Api.Tasks.ValueObjects;
+
+public sealed class TaskTitle
+{
+    public string Value { get; }
+
+    private TaskTitle(string value)
+    {
+        Value = value;
+    }
+
+    public static TaskTitle From(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            throw new ArgumentException("Title cannot be empty", nameof(value));
+        return new TaskTitle(value);
+    }
+
+    public override string ToString() => Value;
+
+    public static implicit operator string(TaskTitle title) => title.Value;
+    public static implicit operator TaskTitle(string value) => From(value);
+}


### PR DESCRIPTION
## Summary
- add generic audit interfaces and domain event support
- introduce strongly typed value objects for task id, title and description
- wire Task entity to emit events and map new types in EF Core
- add lifecycle domain events and validated TaskId
- replace enums with TaskPriority and TaskStatus value objects and map them in EF

## Testing
- `dotnet build OmdhSoft.Tasky/Src/Modules/OmdhSoft.Tasky.Modules.Tasks.Api/OmdhSoft.Tasky.Modules.Tasks.Api.csproj`


------
https://chatgpt.com/codex/tasks/task_b_688f4e370114832f9138e86ae1ecd035