### PR TITLE
refactor: centralize auditable properties

### DIFF
--- a/OmdhSoft.Tasky/Src/Modules/OmdhSoft.Tasky.Modules.Tasks.Api/Tasks/FullAuditableEntity.cs
+++ b/OmdhSoft.Tasky/Src/Modules/OmdhSoft.Tasky.Modules.Tasks.Api/Tasks/FullAuditableEntity.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace OmdhSoft.Tasky.Modules.Tasks.Api.Tasks;
+
+public abstract class FullAuditableEntity<TId> : IFullAuditable<TId>
+{
+    public TId Id { get; protected set; } = default!;
+    public DateTime CreatedAt { get; protected set; } = DateTime.UtcNow;
+    public DateTime? UpdatedAt { get; protected set; }
+    public DateTime? DeletedAt { get; protected set; }
+    public Guid CreatedByUserId { get; protected set; }
+    public Guid? UpdatedByUserId { get; protected set; }
+    public Guid? DeletedByUserId { get; protected set; }
+}

--- a/OmdhSoft.Tasky/Src/Modules/OmdhSoft.Tasky.Modules.Tasks.Api/Tasks/FullAuditableWithEventEntity.cs
+++ b/OmdhSoft.Tasky/Src/Modules/OmdhSoft.Tasky.Modules.Tasks.Api/Tasks/FullAuditableWithEventEntity.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using OmdhSoft.Tasky.Modules.Tasks.Api.Tasks.Events;
+
+namespace OmdhSoft.Tasky.Modules.Tasks.Api.Tasks;
+
+public abstract class FullAuditableWithEventEntity<TId> : FullAuditableEntity<TId>, IFullAuditableWithEvent<TId>
+{
+    private readonly List<IDomainEvent> _domainEvents = new();
+    public IReadOnlyCollection<IDomainEvent> DomainEvents => _domainEvents.AsReadOnly();
+
+    public void AddDomainEvent(IDomainEvent domainEvent)
+    {
+        _domainEvents.Add(domainEvent);
+    }
+
+    public void ClearDomainEvents()
+    {
+        _domainEvents.Clear();
+    }
+}

--- a/OmdhSoft.Tasky/Src/Modules/OmdhSoft.Tasky.Modules.Tasks.Api/Tasks/Task.cs
+++ b/OmdhSoft.Tasky/Src/Modules/OmdhSoft.Tasky.Modules.Tasks.Api/Tasks/Task.cs
@@ -1,39 +1,28 @@
 using System;
-using System.Collections.Generic;
 using OmdhSoft.Tasky.Modules.Tasks.Api.Tasks.Events;
 using OmdhSoft.Tasky.Modules.Tasks.Api.Tasks.ValueObjects;
 
 namespace OmdhSoft.Tasky.Modules.Tasks.Api.Tasks
 {
-    public class Task : IFullAuditableWithEvent<TaskId>
+    public class Task : FullAuditableWithEventEntity<TaskId>
     {
-        public TaskId Id { get; private set; } = TaskId.New();
-        public DateTime CreatedAt { get; private set; } = DateTime.UtcNow;
-        public DateTime? UpdatedAt { get; private set; }
-        public DateTime? DeletedAt { get; private set; }
-        public Guid? DeletedByUserId { get; private set; }
-        public Guid? UpdatedByUserId { get; private set; }
         public TaskTitle Title { get; private set; }
         public TaskDescription Description { get; private set; }
         public TaskPriority Priority { get; private set; }
         public TaskStatus Status { get; private set; }
         public DateTime? DueDate { get; private set; }
-        public Guid CreatedByUserId { get; private set; }
         public Guid? AssignedToUserId { get; private set; }
-
-        private readonly List<IDomainEvent> _domainEvents = new();
-        public IReadOnlyCollection<IDomainEvent> DomainEvents => _domainEvents.AsReadOnly();
 
         private Task() { }
 
         private Task(TaskTitle title, TaskDescription description, TaskPriority priority, Guid createdByUserId, Guid taskListId)
         {
+            Id = TaskId.New();
             Title = title;
             Description = description;
             Priority = priority;
             CreatedByUserId = createdByUserId;
             Status = TaskStatus.Pending;
-            CreatedAt = DateTime.UtcNow;
             AddDomainEvent(new TaskCreatedEvent(Id, Title));
         }
 
@@ -81,16 +70,6 @@ namespace OmdhSoft.Tasky.Modules.Tasks.Api.Tasks
             DeletedByUserId = deletedByUserId;
             Status = TaskStatus.Removed;
             AddDomainEvent(new TaskDeletedEvent(Id));
-        }
-
-        public void AddDomainEvent(IDomainEvent domainEvent)
-        {
-            _domainEvents.Add(domainEvent);
-        }
-
-        public void ClearDomainEvents()
-        {
-            _domainEvents.Clear();
         }
     }
 }


### PR DESCRIPTION
## Summary
- move auditable fields into `FullAuditableEntity` and `FullAuditableWithEventEntity`
- slim `Task` entity to only primary properties

## Testing
- `/root/.dotnet/dotnet build Src/Modules/OmdhSoft.Tasky.Modules.Tasks.Api/OmdhSoft.Tasky.Modules.Tasks.Api.csproj`


------
https://chatgpt.com/codex/tasks/task_b_68909f60b7f0832f87af10ab9031ce0b